### PR TITLE
Store package json

### DIFF
--- a/packages/catalog/lib/indexer/lambda/index.ts
+++ b/packages/catalog/lib/indexer/lambda/index.ts
@@ -72,11 +72,14 @@ export async function handler(event: AWSLambda.SQSEvent, context: AWSLambda.Cont
     const desc = pkg.metadata.description || '';
     const hashtags = (pkg.metadata.keywords || []).map(k => `#${k.replace(/-/g, '_')}`).join(' ');
     const title = `${pkg.name.replace(/@/g, '')} ${pkg.version}`;
-    let twitterHandle = pkg.metadata.author?.twitter;
+
+    // extract twitter handle from package.json/author field (if exists)
+    let twitterHandle = pkg.json.author?.twitter;
     if (twitterHandle && !twitterHandle.startsWith('@')) {
-      twitterHandle = "@" + twitterHandle;
+      twitterHandle = '@' + twitterHandle;
     }
     const author = twitterHandle ? `by ${twitterHandle}` : '';
+
     const status = [
       title,
       pkg.url,
@@ -84,7 +87,8 @@ export async function handler(event: AWSLambda.SQSEvent, context: AWSLambda.Cont
       desc,
       author,
       hashtags,
-    ].join('\n')
+    ].join('\n');
+
     console.log(`POST statuses/update ${JSON.stringify({status})}`);
 
     // publish to a topic, so we can monitor and do other stuffs.

--- a/packages/catalog/lib/lambda-util/schema.ts
+++ b/packages/catalog/lib/lambda-util/schema.ts
@@ -3,13 +3,15 @@ export const enum PackageTableAttributes {
   VERSION = 'version',
   METADATA = 'metadata',
   URL = 'url',
-  TWEETID = 'tweetid'
+  TWEETID = 'tweetid',
+  JSON = 'json'
 }
 
 export interface Package {
   name: string;
   version: string;
   metadata: PackageMetadata;
+  json?: any; // contents of package.json (only available after rendering)
   url?: string;
   tweetid?: string;
 }

--- a/packages/catalog/lib/lambda-util/util.ts
+++ b/packages/catalog/lib/lambda-util/util.ts
@@ -37,6 +37,10 @@ export function toDynamoItem(p: Package): aws.DynamoDB.AttributeMap {
     output[PackageTableAttributes.TWEETID] = { S: p.tweetid };
   }
 
+  if (p.json) {
+    output[PackageTableAttributes.JSON] = { S: JSON.stringify(p.json) };
+  }
+
   return output;
 }
 
@@ -56,7 +60,8 @@ export function fromDynamoItem(dynamoItem: aws.DynamoDB.AttributeMap): Package {
     version: version,
     metadata: JSON.parse(metadataText),
     tweetid: dynamoItem[PackageTableAttributes.TWEETID]?.S,
-    url: dynamoItem[PackageTableAttributes.URL]?.S
+    url: dynamoItem[PackageTableAttributes.URL]?.S,
+    json: dynamoItem[PackageTableAttributes.JSON]?.S,
   };
 }
 
@@ -89,7 +94,8 @@ export function extractPackageStream(sqsEvent: AWSLambda.SQSEvent): Array<Packag
       name: parseStringValue(record.dynamodb, PackageTableAttributes.NAME),
       version: parseStringValue(record.dynamodb, PackageTableAttributes.VERSION),
       metadata: JSON.parse(parseStringValue(record.dynamodb, PackageTableAttributes.METADATA)),
-      url: parseOptionStringValue(record.dynamodb, PackageTableAttributes.URL)
+      url: parseOptionStringValue(record.dynamodb, PackageTableAttributes.URL),
+      json: JSON.parse(parseStringValue(record.dynamodb, PackageTableAttributes.JSON))
     });
   }
 

--- a/packages/catalog/lib/renderer/lambda/index.ts
+++ b/packages/catalog/lib/renderer/lambda/index.ts
@@ -56,6 +56,9 @@ export async function handler(event: SQSEvent) {
           console.log(`Skipping non-jsii module ${name}@${version}`);
           return;
         }
+
+        // store package.json
+        const packageJson = await fs.readFile(path.join(moduleDir, 'package.json'), 'utf-8');
     
         try {
           await docgen.renderDocs({
@@ -85,6 +88,7 @@ export async function handler(event: SQSEvent) {
           TableName: TABLE_NAME,
           Item: toDynamoItem({
             ...record,
+            json: packageJson,
             url: `${BASE_URL}/${objectKeyPrefix}`
           })
         }).promise();


### PR DESCRIPTION
Twitter handle information is not available in the package metadata published by npm but it is available in `package.json`. To that end, we store the entirety of package.json inside the rendering table so we can extract the twitter handle from it