### PR TITLE
adds an optional accountId for renderer topic subscription rights

### DIFF
--- a/packages/catalog/config.ts
+++ b/packages/catalog/config.ts
@@ -26,6 +26,6 @@ export const prod: CatalogStackProps = {
     region: 'us-east-1',
   },
   externalAccountSubscribers: [
-    "536309290949"  // matthew.bonig@gmail.com
+    "536309290949"  // so matthew.bonig@gmail.com can auto-build his constructs when new versions of `core` are released.
   ]
 };

--- a/packages/catalog/config.ts
+++ b/packages/catalog/config.ts
@@ -24,5 +24,8 @@ export const prod: CatalogStackProps = {
   env: {
     account: '499430655523',
     region: 'us-east-1',
-  }
+  },
+  externalAccountSubscribers: [
+    "536309290949"  // matthew.bonig@gmail.com
+  ]
 };


### PR DESCRIPTION
I want to be able to subscribe to the sns topic for when the renderer has completed. This change allows for an optional externalAccountSubscribers to be passed to the CatalogStack and creates a topic policy accordingly.