### PR TITLE
disable @mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@ The Construct Catalog will automatically discover jsii multi-language modules pu
 1. Create a new jsii project, we recommend [projen](https://github.com/eladb/projen):
 
 ```shell
-npx projen new jsii 
-  --name="MY-MODULE"
-  --author-name="MY-NAME"
-  --author-email="MY-EMAIL"
-  --repository="https://..."
+$ npx projen new jsii
 ```
 
 2. Edit your `.projenrc.js` file and add language specific configuration. See [watchful](https://github.com/eladb/cdk-watchful/blob/master/.projenrc.js) as an example.
@@ -33,7 +29,7 @@ npx projen new jsii
     - `twitter` (string): a Twitter handle (with or without the '@'). This handle will be
       "@mentioned" when the catalog tweets about new versions (see this
       [package.json](https://github.com/eladb/cdk-watchful/blob/master/package.json#L5)
-      as an example).
+      as an example). **THIS FEATURE IS TEMPORARILY DISABLED DUE TO TWITTER POLICY :(**
     - `announce` (boolean): indicates if a tweet should be posted when new versions of this module are published (default is `true`).
 
 4. Publish your module to all package managers. Here are some recommended tools:
@@ -51,7 +47,7 @@ npx projen new jsii
   "jsii": { ... }          // jsii config (required)
   "keywords": [ "cdk" ],   // required
   "awscdkio": {            // all optional
-    "twitter": "@account", // @mention in announcement
+    "twitter": "@account", // @mention in announcement (TEMPORARILY DISABLED)
     "announce": true       // this is the default
   }
 }

--- a/packages/catalog/lib/tweeter/lambda/index.ts
+++ b/packages/catalog/lib/tweeter/lambda/index.ts
@@ -75,12 +75,18 @@ export async function handler(event: AWSLambda.SQSEvent, context: AWSLambda.Cont
     const hashtags = (pkg.metadata.keywords || []).map(k => `#${k.replace(/-/g, '_')}`).join(' ');
     const title = `${pkg.name.replace(/@/g, '')} ${pkg.version}`;
 
-    // extract twitter handle from package.json/awscdkio.twitter field (if exists)
-    let twitterHandle = awscdkio.twitter;
-    if (twitterHandle && !twitterHandle.startsWith('@')) {
-      twitterHandle = '@' + twitterHandle;
-    }
-    const author = twitterHandle ? ` by ${twitterHandle}` : '';
+    // --------------------------------------------------------------------------
+    // DISABLED since unsolicited @mentions violate the twitter policy:
+    // https://help.twitter.com/en/rules-and-policies/twitter-automation
+    // --------------------------------------------------------------------------
+    // // extract twitter handle from package.json/awscdkio.twitter field (if exists)
+    // let twitterHandle = awscdkio.twitter;
+    // if (twitterHandle && !twitterHandle.startsWith('@')) {
+    //   twitterHandle = '@' + twitterHandle;
+    // }
+    // const author = twitterHandle ? ` by ${twitterHandle}` : '';
+    // --------------------------------------------------------------------------
+    const author = '';
 
     const status = [
       title + author,


### PR DESCRIPTION
The twitter policy forbids unsolicited @mentions and it appears this might be a cause for blocking our account.