### PR TITLE
feat(catalog-frontend): some touchups

### DIFF
--- a/packages/catalog-frontend/src/App.tsx
+++ b/packages/catalog-frontend/src/App.tsx
@@ -43,7 +43,7 @@ export class App extends React.Component<{}, { packages: schema.Package[], activ
               <Input icon='search' iconPosition='left' placeholder='Search...' onChange={this.onSearchChange} />
               <Label pointing='above' color='blue'>
                 <Icon name='box' aria-hidden='true'/>
-                {new Set(packages.map(pkg => pkg.name)).size} packages selected
+                {new Set(packages.map(pkg => pkg.name)).size} packages available
               </Label>
             </Form.Field>
           </Form>

--- a/packages/catalog-frontend/src/PackageCard.tsx
+++ b/packages/catalog-frontend/src/PackageCard.tsx
@@ -29,23 +29,26 @@ export class PackageCard extends React.Component<PackageCardProps, {}> {
     }
 
     const date = new Date(this.props.package.metadata.date).toLocaleDateString();
+    const author = this.props.package.metadata.author.name;
 
     return (
-      <Card raised>
+      <Card link raised>
         <Card.Content link href={this.props.package.url}>
           <Card.Header className='package-name'>
-            {this.props.package.name} <Label tag size='small' aria-label='Major Version'>{this.props.package.major}.x</Label>
+            {this.props.package.name} <Label tag size='mini' aria-label='Major Version'>{this.props.package.major}.x</Label>
             <Label attached='top right' aria-label='Latest Version'>{this.props.package.version}</Label>
           </Card.Header>
-          <Card.Meta>
-            <span className='date'>Last published: {date}</span>
+          <Card.Meta style={{ marginTop: '0.5rem' }} >
+            <span className='date'>Last published: {date} | {author}</span>
           </Card.Meta>
           <Card.Description aria-label='Package description'>
             {this.props.package.metadata.description}
           </Card.Description>
         </Card.Content>
         <Card.Content extra aria-label='Keywords'>
-          {(this.props.package.metadata.keywords || [])?.sort().map(kw => (<Label>{kw}</Label>))}
+          <Label.Group as='span'>
+            {(this.props.package.metadata.keywords ?? []).sort().map(kw => (<Label>{kw}</Label>))}
+          </Label.Group>
         </Card.Content>
         <Card.Content extra aria-label='Supported Languages'>
           <SupportedLanguageList config={this.props.package.languages} />

--- a/packages/catalog-frontend/src/PackageCard.tsx
+++ b/packages/catalog-frontend/src/PackageCard.tsx
@@ -35,7 +35,7 @@ export class PackageCard extends React.Component<PackageCardProps, {}> {
       <Card link raised>
         <Card.Content link href={this.props.package.url}>
           <Card.Header className='package-name'>
-            {this.props.package.name} <Label tag size='mini' aria-label='Major Version'>{this.props.package.major}.x</Label>
+            {this.props.package.name}
             <Label attached='top right' aria-label='Latest Version'>{this.props.package.version}</Label>
           </Card.Header>
           <Card.Meta style={{ marginTop: '0.5rem' }} >


### PR DESCRIPTION
Just some minor changes:

- When keywords span to a second row the top padding was a little off. 
- Added author name to the card
- Remove Major version label - was a bit tacky and caused clutter 
- Switch `150 packages selected` to `150 packages available`
- Card will now rise a little bit when hovered over.

## Before

<img width="1440" alt="Screen Shot 2021-01-20 at 12 23 59 AM" src="https://user-images.githubusercontent.com/1428812/105100321-d25fb480-5ab5-11eb-954f-b380016b26f5.png">


## After

<img width="1440" alt="Screen Shot 2021-01-20 at 12 23 13 AM" src="https://user-images.githubusercontent.com/1428812/105100266-b9ef9a00-5ab5-11eb-878a-f3a05598f482.png">

