### PR TITLE
chore: stop deploying catalog search stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,3 @@ jobs:
       run: |
         cd packages/catalog
         npx cdk deploy --require-approval=never construct-catalog-prod
-        npx cdk deploy --require-approval=never construct-catalog-search-prod


### PR DESCRIPTION
We decided to implement catalog search as client-side instead of using an elastic search backend on top of EKS. This commit removes the catalog search stack deployment from the GitHub workflow.